### PR TITLE
Add support for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This library has (so far) support for:
 - Windows
 - Linux & Android
 - macOS & iOS
+- FreeBSD
 
 <!-- Links -->
 [travis-shield]: https://img.shields.io/travis/darfink/region-rs.svg?style=flat-square&label=travis

--- a/src/os/freebsd.rs
+++ b/src/os/freebsd.rs
@@ -1,0 +1,75 @@
+use libc::{c_int, c_void, getpid, pid_t};
+use {Error, Protection, Region, Result};
+
+pub fn get_region(address: *const u8) -> Result<Region> {
+  unsafe {
+    let mut vm_cnt = 0;
+    let vm = kinfo_getvmmap(getpid(), &mut vm_cnt);
+    if vm.is_null() {
+      return Err(Error::NullAddress);
+    }
+
+    for i in 0..vm_cnt {
+      // Since the struct size is given in the struct, we can use it to be future-proof
+      // (we won't need to update the definition here when new fields are added)
+      let entry = &*((vm as *const c_void).offset(i as isize * (*vm).kve_structsize as isize)
+        as *const kinfo_vmentry);
+      if address >= entry.kve_start as *const _ && address < entry.kve_end as *const _ {
+        return Ok(Region {
+          base: entry.kve_start as *const _,
+          size: (entry.kve_end - entry.kve_start) as _,
+          guarded: false,
+          protection: Protection::from_native(entry.kve_protection),
+          shared: entry.kve_type == KVME_TYPE_DEFAULT,
+        });
+      }
+    }
+
+    Err(Error::FreeMemory)
+  }
+}
+
+impl Protection {
+  fn from_native(protection: c_int) -> Self {
+    let mut result = Protection::None;
+
+    if (protection & KVME_PROT_READ) == KVME_PROT_READ {
+      result |= Protection::Read;
+    }
+
+    if (protection & KVME_PROT_WRITE) == KVME_PROT_WRITE {
+      result |= Protection::Write;
+    }
+
+    if (protection & KVME_PROT_EXEC) == KVME_PROT_EXEC {
+      result |= Protection::Execute;
+    }
+
+    result
+  }
+}
+
+#[repr(C)]
+struct kinfo_vmentry {
+  kve_structsize: c_int,
+  kve_type: c_int,
+  kve_start: u64,
+  kve_end: u64,
+  kve_offset: u64,
+  kve_vn_fileid: u64,
+  kve_vn_fsid_freebsd11: u32,
+  kve_flags: c_int,
+  kve_resident: c_int,
+  kve_private_resident: c_int,
+  kve_protection: c_int,
+}
+
+const KVME_TYPE_DEFAULT: c_int = 1;
+const KVME_PROT_READ: c_int = 1;
+const KVME_PROT_WRITE: c_int = 2;
+const KVME_PROT_EXEC: c_int = 4;
+
+#[link(name = "util")]
+extern "C" {
+  fn kinfo_getvmmap(pid: pid_t, cntp: *mut c_int) -> *mut kinfo_vmentry;
+}

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -21,3 +21,9 @@ mod linux;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use self::linux::get_region;
+
+#[cfg(target_os = "freebsd")]
+mod freebsd;
+
+#[cfg(target_os = "freebsd")]
+pub use self::freebsd::get_region;


### PR DESCRIPTION
For some reason function pointers are something like `0x103106f`, not in the executable region..

```
0x1021000 0x104e000 45 854 0xfffff802d5b22a00 r-- 3 1 0x1000 COW NC vnode …/target/debug/deps/region-d4b611cfd5dce967 NCH -1
0x104e000 0x10be000 112 854 0xfffff802d5b22a00 r-x 3 1 0x1000 COW NC vnode …/target/debug/deps/region-d4b611cfd5dce967 NCH -1
```

