### PR TITLE
feat: add support for illumos

### DIFF
--- a/src/os/illumos.rs
+++ b/src/os/illumos.rs
@@ -1,0 +1,101 @@
+use crate::{Error, Protection, Region, Result};
+use std::fs::File;
+use std::io::Read;
+use take_until::TakeUntilExt;
+
+// As per proc(4), the file "/proc/$PID/map" contains an array of C structs of
+// type "prmap_t".  The layout of this struct, and thus this file, is a stable
+// interface.
+const PRMAPSZ: usize = 64;
+#[derive(Debug)]
+#[repr(C)]
+struct PrMap {
+  pr_vaddr: *const (),
+  pr_size: usize,
+  pr_mapname: [i8; PRMAPSZ],
+  pr_offset: isize,
+  pr_mflags: i32,
+  pr_pagesize: i32,
+  pr_shmid: i32,
+  _pr_filler: [i32; 1],
+}
+
+const ELEMENT_SIZE: usize = std::mem::size_of::<PrMap>();
+
+// These come from <sys/procfs.h>, describing bits in the pr_mflags member:
+const MA_EXEC: i32 = 0x1;
+const MA_WRITE: i32 = 0x2;
+const MA_READ: i32 = 0x4;
+const MA_SHARED: i32 = 0x8;
+
+pub struct PrMapIterator {
+  buf: Vec<u8>,
+  idx: usize,
+}
+
+impl Iterator for PrMapIterator {
+  type Item = Result<Region>;
+
+  fn next(&mut self) -> Option<Result<Region>> {
+    let (pfx, maps, sfx) = unsafe { self.buf.align_to::<PrMap>() };
+
+    if !pfx.is_empty() || !sfx.is_empty() {
+      panic!(
+        "data was not aligned ({}; {}/{}/{})?",
+        self.buf.len(),
+        pfx.len(),
+        maps.len(),
+        sfx.len()
+      );
+    }
+
+    if let Some(map) = maps.get(self.idx) {
+      let mut protection = Protection::NONE;
+      if map.pr_mflags & MA_READ != 0 {
+        protection |= Protection::READ;
+      }
+      if map.pr_mflags & MA_WRITE != 0 {
+        protection |= Protection::WRITE;
+      }
+      if map.pr_mflags & MA_EXEC != 0 {
+        protection |= Protection::EXECUTE;
+      }
+
+      let reg = Region {
+        base: map.pr_vaddr,
+        protection,
+        shared: map.pr_mflags & MA_SHARED != 0,
+        size: map.pr_size,
+        ..Default::default()
+      };
+
+      self.idx += 1;
+      Some(Ok(reg))
+    } else {
+      None
+    }
+  }
+}
+
+pub fn query<T>(origin: *const T, size: usize) -> Result<impl Iterator<Item = Result<Region>>> {
+  // Do not use a buffered reader here: as much as possible, we want a single
+  // large read(2) call to the proc file.
+  let mut file = File::open("/proc/self/map").map_err(Error::SystemCall)?;
+  let mut buf: Vec<u8> = Vec::with_capacity(8 * ELEMENT_SIZE);
+
+  let sz = file.read_to_end(&mut buf).map_err(Error::SystemCall)?;
+  if sz % ELEMENT_SIZE != 0 {
+    return Err(Error::ProcfsInput(format!(
+      "file size {} is not a multiple of prmap_t size ({})",
+      sz, ELEMENT_SIZE
+    )));
+  }
+
+  let upper_bound = (origin as usize).saturating_add(size);
+  let iterator = PrMapIterator { buf, idx: 0 }
+    .skip_while(move |res| matches!(res, Ok(reg) if reg.as_range().end <= origin as usize))
+    .take_while(move |res| !matches!(res, Ok(reg) if reg.as_range().start >= upper_bound))
+    .take_until(|res| res.is_err())
+    .fuse();
+  Ok(iterator)
+}

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -27,3 +27,9 @@ mod freebsd;
 
 #[cfg(target_os = "freebsd")]
 pub use self::freebsd::*;
+
+#[cfg(target_os = "illumos")]
+mod illumos;
+
+#[cfg(target_os = "illumos")]
+pub use self::illumos::*;


### PR DESCRIPTION
This commit adds support for the [illumos](https://illumos.org) operating system.  We have a proc file system that is somewhat similar to Linux, except that it generally contains binary structures rather than human readable text.

The most relevant illumos manual page is [proc(4)](https://illumos.org/man/4/proc).  You can see the `prmap_t` and associated constants in the [`sys/procfs.h`](https://code.illumos.org/plugins/gitiles/illumos-gate/+/refs/heads/master/usr/src/uts/common/sys/procfs.h#322) header file.

I ran the tests, which all pass:

```
$ pfexec cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running target/debug/deps/region-6c57251c0f124716

running 20 tests
test lock::tests::unlock_mapped_pages_succeeds ... ok
test os::unix::tests::protection_flags_are_mapped_to_native ... ok
test lock::tests::lock_mapped_pages_succeeds ... ok
test page::tests::page_rounding_works ... ok
test page::tests::page_size_is_reasonable ... ok
test protect::tests::protect_can_alter_text_segments ... ok
test protect::tests::protect_null_fails ... ok
test query::tests::query_range_has_inclusive_lower_and_exclusive_upper_bound ... ok
test query::tests::query_range_returns_both_regions_for_straddling_range ... ok
test query::tests::query_returns_correct_region_for_text_segment ... ok
test query::tests::query_returns_one_region_for_identical_adjacent_pages ... ok
test query::tests::query_returns_unmapped_for_oob_address ... ok
test tests::round_to_page_boundaries_works ... ok
test protect::tests::protect_with_handle_resets_protection ... ok
test query::tests::query_range_does_not_return_unmapped_regions ... ok
test query::tests::query_range_can_iterate_over_entire_process ... ok
test protect::tests::protect_has_inclusive_lower_and_exclusive_upper_bound ... ok
test query::tests::query_is_not_off_by_one ... ok
test protect::tests::protect_updates_both_pages_for_straddling_range ... ok
test protect::tests::protect_with_handle_only_resets_protection_of_affected_pages ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests region

running 11 tests
test src/lib.rs - (line 33) ... ok
test src/protect.rs - protect::protect_with_handle (line 66) ... ignored
test /ws/cache/rustup/registry/src/github.com-1ecc6299db9ec823/bitflags-1.2.1/src/lib.rs - protect::Protection (line 413) ... ok
test src/lib.rs - (line 42) ... ok
test src/page.rs - page::size (line 13) ... ok
test src/page.rs - page::floor (line 32) ... ok
test src/lock.rs - lock::lock (line 19) ... ok
test src/protect.rs - protect::protect (line 27) ... ok
test src/page.rs - page::ceil (line 47) ... ok
test src/query.rs - query::query (line 22) ... ok
test src/query.rs - query::query_range (line 66) ... ok

test result: ok. 10 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

I ran `cargo fmt` and used the style it suggested -- hopefully that is OK!  Please let me know if you want any changes.