### PR TITLE
feat: isolated tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2"
 take-until = "0.1.0"
 
 [dev-dependencies]
-memmap = "0.7"
+mmap = { package = "mmap-fixed", version = "0.1.5" }
 
 [target."cfg(any(target_os = \"macos\", target_os = \"ios\"))".dependencies]
 mach = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "1.0"
 libc = "0.2"
 take-until = "0.1.0"
 
-[dev-dependencies]
+[target."cfg(unix)".dev-dependencies]
 mmap = { package = "mmap-fixed", version = "0.1.5" }
 
 [target."cfg(any(target_os = \"macos\", target_os = \"ios\"))".dependencies]

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -76,7 +76,7 @@ unsafe impl Sync for LockGuard {}
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::tests::alloc_pages;
+  use crate::tests::util::alloc_pages;
   use crate::{page, Protection};
 
   #[test]

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -140,7 +140,7 @@ impl Protection {
     }
   }
 
-  fn to_native(self) -> winapi::shared::minwindef::DWORD {
+  pub(crate) fn to_native(self) -> winapi::shared::minwindef::DWORD {
     match self {
       Protection::NONE => winapi::um::winnt::PAGE_NOACCESS,
       Protection::READ => winapi::um::winnt::PAGE_READONLY,

--- a/src/protect.rs
+++ b/src/protect.rs
@@ -175,7 +175,7 @@ bitflags! {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::tests::alloc_pages;
+  use crate::tests::util::alloc_pages;
   use crate::{page, query, query_range};
 
   #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -86,7 +86,7 @@ pub fn query_range<T>(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::tests::alloc_pages;
+  use crate::tests::util::alloc_pages;
   use crate::{page, Protection};
 
   #[test]


### PR DESCRIPTION
Historically, the majority of tests have been dependent on the
`alloc_pages` utility function. This has been troublesome due to it not
being able to generate adjacent pages with specific page permissions.
Therefore `protect` was used, rendering the utility function
self-reliant on the crate itself, therefore not isolating the test
fixture from the implementation.

This commit introduces an implementation of `alloc_pages` that is not
dependent on the library itself. This is achieved by identifying a
region with enough memory available, and allocating one page at a time
with the expected properties.