### PR TITLE
fix querying of regions with submaps on macos and add max_protection field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@ pub struct Region {
   guarded: bool,
   /// Protection of the region
   protection: Protection,
+  /// Maximum protection of the region
+  max_protection: Protection,
   /// Whether the region is shared or not
   shared: bool,
   /// Size of the region (multiple of page size)
@@ -224,6 +226,7 @@ impl Default for Region {
       reserved: false,
       guarded: false,
       protection: Protection::NONE,
+      max_protection: Protection::NONE,
       shared: false,
       size: 0,
     }


### PR DESCRIPTION
submaps were being ignored, region::query returned the topmost page.
switch to using mach_vm_region_recurse with a max depth

particularly, mach_vm_region returns the top level map, not that of a potential submap at a queried address, while mach_vm_region_recurse can return the details of the lowest map

the old functionality might be wanted at times, too, perhaps a macos specific query parameter makes sense?

additionally add a max_protection field to the Region structure