### PR TITLE
Fix clippy lints and upgrade bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/darfink/region-rs"
 version = "3.0.0"
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "2.4"
 libc = "=0.2.107" # Locked for OpenBSD 6.9 compatibility
 
 [target."cfg(any(target_os = \"macos\", target_os = \"ios\"))".dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,8 @@ bitflags! {
   /// let combine = Protection::READ | Protection::WRITE;
   /// let shorthand = Protection::READ_WRITE;
   /// ```
-  #[derive(Default)]
+  #[repr(transparent)]
+  #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
   pub struct Protection: usize {
     /// No access allowed at all.
     const NONE = 0;
@@ -262,13 +263,13 @@ bitflags! {
     /// Execute access; this may not be allowed depending on DEP.
     const EXECUTE = (1 << 3);
     /// Read and execute shorthand.
-    const READ_EXECUTE = (Self::READ.bits | Self::EXECUTE.bits);
+    const READ_EXECUTE = (Self::READ.bits() | Self::EXECUTE.bits());
     /// Read and write shorthand.
-    const READ_WRITE = (Self::READ.bits | Self::WRITE.bits);
+    const READ_WRITE = (Self::READ.bits() | Self::WRITE.bits());
     /// Read, write and execute shorthand.
-    const READ_WRITE_EXECUTE = (Self::READ.bits | Self::WRITE.bits | Self::EXECUTE.bits);
+    const READ_WRITE_EXECUTE = (Self::READ.bits() | Self::WRITE.bits() | Self::EXECUTE.bits());
     /// Write and execute shorthand.
-    const WRITE_EXECUTE = (Self::WRITE.bits | Self::EXECUTE.bits);
+    const WRITE_EXECUTE = (Self::WRITE.bits() | Self::EXECUTE.bits());
   }
 }
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -42,12 +42,16 @@ impl Iterator for QueryIter {
 
     let mut depth = u32::MAX;
     let result = unsafe {
+      #[allow(clippy::ptr_as_ptr)]
+      let recurse_info =
+        (&mut info.protection as *mut _) as mach::vm_region::vm_region_recurse_info_t;
+
       mach::vm::mach_vm_region_recurse(
         mach::traps::mach_task_self(),
         &mut self.region_address,
         &mut region_size,
         &mut depth,
-        (&mut info as *mut _) as mach::vm_region::vm_region_recurse_info_t,
+        recurse_info,
         &mut mach::vm_region::vm_region_submap_info_64::count(),
       )
     };


### PR DESCRIPTION
Upgrading bitflags was required to get rid of a clippy lint.

I tested this on a Mac M1 both in MacOS and on `debian:latest` through docker (on the same machine, so aarch64) by doing `cargo test -- --test-threads=1`.  I assume that test failures are expected when run in parallel because the regions from other tests may affect things like queries; if that's not expected... well then consider this a heads up ^_^

The only downside I could find is that `bitflags` 2.X requires Rust 1.56 or newer. Since this project doesn't officially define a MSRV, I don't know if that's problematic.