### PR TITLE
Replace mach dependency with mach2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "1.0"
 libc = "0.2"
 
 [target."cfg(any(target_os = \"macos\", target_os = \"ios\"))".dependencies]
-mach = "0.3"
+mach2 = "0.4"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["basetsd", "minwindef", "sysinfoapi", "memoryapi", "winnt"] }


### PR DESCRIPTION
`mach` is pretty much unmaintained. This PR replaces it with `mach2` which is more well-maintained. Context: wasmerio/wasmer#4222

There is also a patch for the `3.0.0` release available in the [`3.0.0-patch-mach2` branch](https://github.com/wasmerio/region-rs/tree/3.0.0-patch-mach2) of wasmerio/region-rs.